### PR TITLE
Refactor sinks to be stateful; Add a logger sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v0.2.0
+
+### Changed
+
+- `Lambda` sink renamed to `Stdout` to reflect its destination rather than its intended use
+- The currently configured sink is now accessed through the `Config` object rather than from the root namespace
+- Improved test coverage
+
+### Added
+
+- A `Logger` sink to emit to a Ruby Logger instance, for logfile output
+
 ## v0.1.0
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aws-embedded-metrics-customink (0.1.0)
+    aws-embedded-metrics-customink (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -29,11 +29,19 @@ gem 'aws-embedded-metrics-customink'
 ```
 ## Usage
 
-Simple configuration.
+Simple configuration:
 
 ```ruby
 Aws::Embedded::Metrics.configure do |c|
   c.namespace = 'MyApplication'
+end
+```
+
+Using the `Logger` sink to write to a log file:
+
+```ruby
+Aws::Embedded::Metrics.configure do |c|
+  c.sink = Aws::Embedded::Metrics::Sinks::Logger.new(Rails.logger, level: :info)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Using the `Logger` sink to write to a log file:
 
 ```ruby
 Aws::Embedded::Metrics.configure do |c|
-  c.sink = Aws::Embedded::Metrics::Sinks::Logger.new(Rails.logger, level: :info)
+  c.sink = Aws::Embedded::Metrics::Sinks::Logger.new(Rails.logger)
 end
 ```
 

--- a/lib/aws-embedded-metrics-customink.rb
+++ b/lib/aws-embedded-metrics-customink.rb
@@ -1,13 +1,17 @@
 require 'json'
 require 'benchmark'
 require 'aws-embedded-metrics-customink/version'
-require 'aws-embedded-metrics-customink/config'
 require 'aws-embedded-metrics-customink/sinks'
+require 'aws-embedded-metrics-customink/config'
 require 'aws-embedded-metrics-customink/logger'
 
 module Aws
   module Embedded
     module Metrics
+
+      def config
+        Config.config
+      end
 
       def configure
         Config.configure { |c| yield(c) }
@@ -21,10 +25,6 @@ module Aws
         Logger.new.tap do |l|
           l.metrics { |m| yield(m) } if block_given?
         end
-      end
-
-      def sink
-        @sink ||= Sinks::Lambda.new
       end
 
       extend self

--- a/lib/aws-embedded-metrics-customink/config.rb
+++ b/lib/aws-embedded-metrics-customink/config.rb
@@ -3,6 +3,8 @@ module Aws
     module Metrics
       module Config
 
+        DEFAULT_SINK = Sinks::Stdout
+
         def configure
           yield(config)
           config
@@ -20,7 +22,7 @@ module Aws
 
         class Configuration
 
-          attr_writer :namespace
+          attr_writer :namespace, :sink
 
           def reconfigure
             instance_variables.each { |var| instance_variable_set var, nil }
@@ -30,7 +32,12 @@ module Aws
 
           def namespace
             return @namespace if defined?(@namespace)
+
             ENV['AWS_EMF_NAMESPACE'] || 'aws-embedded-metrics'
+          end
+
+          def sink
+            @sink ||= DEFAULT_SINK.new
           end
 
         end

--- a/lib/aws-embedded-metrics-customink/logger.rb
+++ b/lib/aws-embedded-metrics-customink/logger.rb
@@ -3,8 +3,8 @@ module Aws
     module Metrics
       class Logger
 
-        def initialize(sink = Sinks::Lambda)
-          @sink = sink.new
+        def initialize(sink = Config.config.sink)
+          @sink = sink
           @namespace = Config.config.namespace
           @dimensions = []
           @metrics = []
@@ -18,7 +18,7 @@ module Aws
         end
 
         def flush
-          Metrics.sink.accept(message) unless empty?
+          @sink.accept(message) unless empty?
         end
 
         def put_dimension(name, value)

--- a/lib/aws-embedded-metrics-customink/sinks.rb
+++ b/lib/aws-embedded-metrics-customink/sinks.rb
@@ -1,1 +1,2 @@
-require 'aws-embedded-metrics-customink/sinks/lambda'
+require 'aws-embedded-metrics-customink/sinks/logger'
+require 'aws-embedded-metrics-customink/sinks/stdout'

--- a/lib/aws-embedded-metrics-customink/sinks/logger.rb
+++ b/lib/aws-embedded-metrics-customink/sinks/logger.rb
@@ -1,0 +1,22 @@
+module Aws
+  module Embedded
+    module Metrics
+      module Sinks
+        class Logger
+
+          attr_reader :logger, :level
+
+          def initialize(logger, level: 'info')
+            @logger = logger
+            @level = level
+          end
+
+          def accept(message)
+            logger.public_send(level, JSON.dump(message))
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/aws-embedded-metrics-customink/sinks/logger.rb
+++ b/lib/aws-embedded-metrics-customink/sinks/logger.rb
@@ -6,7 +6,7 @@ module Aws
 
           attr_reader :logger, :level
 
-          def initialize(logger, level: 'info')
+          def initialize(logger, level: :info)
             @logger = logger
             @level = level
           end

--- a/lib/aws-embedded-metrics-customink/sinks/logger.rb
+++ b/lib/aws-embedded-metrics-customink/sinks/logger.rb
@@ -8,7 +8,7 @@ module Aws
 
           def initialize(logger, level: :info)
             @logger = logger
-            @level = level
+            @level = level.to_sym
           end
 
           def accept(message)

--- a/lib/aws-embedded-metrics-customink/sinks/stdout.rb
+++ b/lib/aws-embedded-metrics-customink/sinks/stdout.rb
@@ -2,7 +2,7 @@ module Aws
   module Embedded
     module Metrics
       module Sinks
-        class Lambda
+        class Stdout
 
           def accept(message)
             puts JSON.dump(message)

--- a/lib/aws-embedded-metrics-customink/version.rb
+++ b/lib/aws-embedded-metrics-customink/version.rb
@@ -1,7 +1,7 @@
 module Aws
   module Embedded
     module Metrics
-      VERSION = '0.1.0'.freeze
+      VERSION = '0.2.0'.freeze
     end
   end
 end

--- a/test/cases/sinks/logger_test.rb
+++ b/test/cases/sinks/logger_test.rb
@@ -1,0 +1,22 @@
+require 'logger'
+require 'stringio'
+
+module Sinks
+  class LoggerTest < TestCase
+    let(:logger) { Logger.new(StringIO.new) }
+    let(:level) { :info }
+    let(:msg) { { hello: 'world' } }
+    let(:sink) { Aws::Embedded::Metrics::Sinks::Logger.new(logger, level: level) }
+
+    it 'initializes with an instance of a logger and a log level' do
+      expect(sink).must_be_instance_of Aws::Embedded::Metrics::Sinks::Logger
+      expect(sink.logger).must_equal logger
+      expect(sink.level).must_equal level
+    end
+
+    it '#accept dumps its message as json to the logger at the prescribed log level' do
+      logger.expects(:info).with(JSON.dump(msg)).once
+      sink.accept(msg)
+    end
+  end
+end

--- a/test/cases/sinks/stdout_test.rb
+++ b/test/cases/sinks/stdout_test.rb
@@ -1,0 +1,15 @@
+module Sinks
+  class StdoutTest < TestCase
+    let(:msg) { { hello: 'world' } }
+    let(:sink) { Aws::Embedded::Metrics::Sinks::Stdout.new }
+
+    it 'initializes with no arguments' do
+      expect(sink).must_be_instance_of Aws::Embedded::Metrics::Sinks::Stdout
+    end
+
+    it '#accept dumps its message as json to stdout' do
+      STDOUT.expects(:puts).with(JSON.dump(msg)).once
+      sink.accept(msg)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,18 +8,15 @@ require 'minitest/autorun'
 class TestCase < MiniTest::Spec
 
   before do
-    reconfigure
-    setup_test_sink
+    configure
   end
 
   private
 
-  def reconfigure
-    Aws::Embedded::Metrics.reconfigure
-  end
-
-  def setup_test_sink
-    Aws::Embedded::Metrics.stubs sink: test_sink
+  def configure
+    Aws::Embedded::Metrics.reconfigure do |c|
+      c.sink = test_sink
+    end
   end
 
   def test_sink


### PR DESCRIPTION
### Description

Currently this gem is only capable of writing to stdout via `puts`. I'd like to use it to emit from an EC2 instance into a log file, meaning I need to pass it an instance of a Logger to buffer output.

### Changes

- Refactor sinks to be stateful
- Rename `Lambda` sink to `Stdout` for mental-model alignment with the new one (all sinks are now named after their output 
mechanism)
- Add `Logger` sink to accept any `Logger` instance and a `level` kwarg
- Beefed up test coverage around sinks