### PR TITLE
Simple per-request singleton/delegator for metrics instance in Rails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v0.5.0
+
+### Added
+
+- Simple singleton/delegator for metrics instance in Rails.
+
 ## v0.4.0
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aws-embedded-metrics-customink (0.4.0)
+    aws-embedded-metrics-customink (0.5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/aws-embedded-metrics-customink.rb
+++ b/lib/aws-embedded-metrics-customink.rb
@@ -6,6 +6,7 @@ require 'aws-embedded-metrics-customink/version'
 require 'aws-embedded-metrics-customink/sinks'
 require 'aws-embedded-metrics-customink/config'
 require 'aws-embedded-metrics-customink/logger'
+require 'aws-embedded-metrics-customink/instance' if defined?(Rails)
 
 module Aws
   module Embedded

--- a/lib/aws-embedded-metrics-customink/instance.rb
+++ b/lib/aws-embedded-metrics-customink/instance.rb
@@ -1,0 +1,18 @@
+module Aws
+  module Embedded
+    module Metrics
+      class Instance < SimpleDelegator
+        mattr_accessor :instance
+
+        extend SingleForwardable
+
+        def_delegators :instance,
+                       :flush,
+                       :benchmark,
+                       :put_dimension,
+                       :put_metric,
+                       :set_property
+      end
+    end
+  end
+end

--- a/lib/aws-embedded-metrics-customink/version.rb
+++ b/lib/aws-embedded-metrics-customink/version.rb
@@ -1,7 +1,7 @@
 module Aws
   module Embedded
     module Metrics
-      VERSION = '0.4.0'.freeze
+      VERSION = '0.5.0'.freeze
     end
   end
 end


### PR DESCRIPTION
## Using Rails?

Want to instrument metrics deep in your code during the request/response lifecycle? Consider creating a PORO like this `Metrics` example.

```ruby
class MyMetrics < Aws::Embedded::Metrics::Instance
end
```

This object is ready to use as a per-request singleton that acts as a simple delegator to all metrics/logger methods. A great way to hook it up for your application is in ApplicationController.

```ruby
class ApplicationController < ActionController::Base
  around_action :embedded_metrics
  private
  def embedded_metrics
    Aws::Embedded::Metrics.logger do |metrics|
      MyMetrics.instance = MyMetrics.new(metrics)
      yield
    end
  end
end
```

Now you can happily instrument your code.

```ruby
proof, time = MyMetrics.benchmark { @imagebuilder.data }
MyMetrics.put_metric 'ImageBuilderTime', time, 'Milliseconds'
MyMetrics.set_property 'ImageId', params[:image_id]
```