### PR TITLE
Add require hint to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ gem 'aws-embedded-metrics-customink'
 ```
 ## Usage
 
+If using outside of Rails, require the gem:
+```ruby
+require 'aws-embedded-metrics-customink'
+```
+
 Simple configuration:
 
 ```ruby


### PR DESCRIPTION
### Description
Docs assume that you're running the gem in Rails - if you're not, you have to `require` the gem manually.