### PR TITLE
Add the EcsFargate sink and Unit reference class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v0.7.0
+
+### Added
+
+- A new sink now exists, `EcsFargate`! Today the sink assumes you're using the `awsvpc` network configuration for your containers.
+- Included a new dependency, `tcp-client`. Originally a small hand-written TCP client was used but it proved unreliable and well outside the scope of this library.
+- Added the new `Units` class for easy reference to the accepted metric units.
+
 ## v0.6.0
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,16 @@
 PATH
   remote: .
   specs:
-    aws-embedded-metrics-customink (0.6.0)
+    aws-embedded-metrics-customink (0.7.0)
       concurrent-ruby
+      tcp-client
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.1)
     coderay (1.1.3)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.10)
     method_source (1.0.0)
     minitest (5.14.1)
     mocha (1.11.2)
@@ -35,6 +36,7 @@ GEM
     rubocop-ast (0.2.0)
       parser (>= 2.7.0.1)
     ruby-progressbar (1.10.1)
+    tcp-client (0.11.2)
     unicode-display_width (1.7.0)
 
 PLATFORMS
@@ -49,4 +51,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.1.2
+   2.3.5

--- a/aws-embedded-metrics-customink.gemspec
+++ b/aws-embedded-metrics-customink.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.add_dependency 'concurrent-ruby'
+  spec.add_dependency 'tcp-client'
 end

--- a/lib/aws-embedded-metrics-customink.rb
+++ b/lib/aws-embedded-metrics-customink.rb
@@ -6,6 +6,7 @@ require 'aws-embedded-metrics-customink/version'
 require 'aws-embedded-metrics-customink/sinks'
 require 'aws-embedded-metrics-customink/config'
 require 'aws-embedded-metrics-customink/logger'
+require 'aws-embedded-metrics-customink/units'
 require 'aws-embedded-metrics-customink/instance' if defined?(Rails)
 
 module Aws

--- a/lib/aws-embedded-metrics-customink/config.rb
+++ b/lib/aws-embedded-metrics-customink/config.rb
@@ -22,7 +22,12 @@ module Aws
 
         class Configuration
 
-          attr_writer :namespace, :sink
+          attr_writer :log_group_name,
+                      :log_stream_name,
+                      :namespace,
+                      :service_name,
+                      :service_type,
+                      :sink
 
           def reconfigure
             instance_variables.each { |var| instance_variable_set var, nil }
@@ -30,16 +35,39 @@ module Aws
             self
           end
 
+          def log_group_name
+            return @log_group_name if defined?(@log_group_name)
+
+            ENV.fetch('AWS_EMF_LOG_GROUP_NAME', nil)
+          end
+
+          def log_stream_name
+            return @log_stream_name if defined?(@log_stream_name)
+
+            ENV.fetch('AWS_EMF_LOG_STREAM_NAME', nil)
+          end
+
           def namespace
             return @namespace if defined?(@namespace)
 
-            ENV['AWS_EMF_NAMESPACE'] || 'aws-embedded-metrics'
+            ENV.fetch('AWS_EMF_NAMESPACE', 'aws-embedded-metrics')
+          end
+
+          def service_name
+            return @service_name if defined?(@service_name)
+
+            ENV.fetch('AWS_EMF_SERVICE_NAME', nil)
+          end
+
+          def service_type
+            return @service_type if defined?(@service_type)
+
+            ENV.fetch('AWS_EMF_SERVICE_TYPE', nil)
           end
 
           def sink
             @sink ||= DEFAULT_SINK.new
           end
-
         end
       end
     end

--- a/lib/aws-embedded-metrics-customink/logger.rb
+++ b/lib/aws-embedded-metrics-customink/logger.rb
@@ -54,21 +54,22 @@ module Aws
         end
 
         def message
-          cw_metrics = {
-            'Namespace' => @namespace,
-            'Dimensions' => [@dimensions.map(&:keys).flatten],
-            'Metrics' => @metrics
+          aws = {
+            'Timestamp' => timestamp,
+            'CloudWatchMetrics' => [{
+              'Namespace' => @namespace,
+              'Dimensions' => [@dimensions.map(&:keys).flatten],
+              'Metrics' => @metrics
+            }]
           }
-          cw_metrics['LogGroupName'] = @log_group_name if @log_group_name
-          cw_metrics['LogStreamName'] = @log_stream_name if @log_stream_name
-          cw_metrics['ServiceName'] = @service_name if @service_name
-          cw_metrics['ServiceType'] = @service_type if @service_type
+
+          aws['LogGroupName'] = @log_group_name if @log_group_name
+          aws['LogStreamName'] = @log_stream_name if @log_stream_name
+          aws['ServiceName'] = @service_name if @service_name
+          aws['ServiceType'] = @service_type if @service_type
 
           {
-            '_aws' => {
-              'Timestamp' => timestamp,
-              'CloudWatchMetrics' => [cw_metrics]
-            }
+            '_aws' => aws
           }.tap do |m|
             @dimensions.each { |dim| m.merge!(dim) }
             m.merge!(@properties)

--- a/lib/aws-embedded-metrics-customink/sinks.rb
+++ b/lib/aws-embedded-metrics-customink/sinks.rb
@@ -1,2 +1,5 @@
+require 'aws-embedded-metrics-customink/sinks/ecs_fargate'
 require 'aws-embedded-metrics-customink/sinks/logger'
 require 'aws-embedded-metrics-customink/sinks/stdout'
+
+require 'aws-embedded-metrics-customink/sinks/sink_error'

--- a/lib/aws-embedded-metrics-customink/sinks/ecs_fargate.rb
+++ b/lib/aws-embedded-metrics-customink/sinks/ecs_fargate.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'socket'
+require 'tcp-client'
+
+module Aws
+  module Embedded
+    module Metrics
+      module Sinks
+        #
+        # Create a sink that will communicate to a CloudWatch Log Agent over a TCP connection.
+        # This is intended to be used on ECS Fargate instances where the CloudWatch Log Agent
+        # is deployed as a side-car container.
+        #
+        # See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Generation_CloudWatch_Agent.html
+        # for configuration information
+        class EcsFargate
+          DEFAULT_ENV_VAR_NAME = 'AWS_EMF_AGENT_ENDPOINT'
+          attr_reader :queue
+
+          #
+          # Create a new Fargate sink. It will use the `AWS_EMF_AGENT_ENDPOINT` environment variable by default to
+          # connect to a CloudWatch Metric Agent side-car container.
+          # This was built as a performance-critical piece of code since metrics are often a high-volume item.
+          # `#accept`, which is what takes in messages to send to the CW Metric Agent, puts messages into a thread-safe
+          # queue. A separate thread is then picking up from that queue and sending the messages over a persistent
+          # TCP connection to the agent.
+          #
+          # **Creating a new EcsFargate sink will create a new thread and connection to the agent**.
+          # This sink is intended to be used sparingly.
+          #
+          # Messages that time out or can't be sent are put back at the end of the queue.
+          # If a message is enqueued and the queue is full, the message is dropped and a warning is logged.
+          #
+          # @param conn_str [String] A connection string, formatted like 'tcp://127.0.0.1:25888'
+          # @param max_queue_size [Numeric] The number of messages to buffer in-memory.
+          # @param conn_timeout_secs [Numeric] The number of seconds before timing out the connection to the agent.
+          # @param write_timeout_secs [Numeric] The number of seconds to wait before timing out a write.
+          # @param logger [Logger] A standard Ruby logger to propagate warnings and errors.
+          #   Suggested to use Rails.logger.
+          def initialize(conn_str: ENV.fetch(DEFAULT_ENV_VAR_NAME, nil),
+                         max_queue_size: 100_000,
+                         conn_timeout_secs: 10,
+                         write_timeout_secs: 10,
+                         logger: nil)
+            if conn_str.nil?
+              raise Sinks::Error, "Must specify a connection string or set environment variable #{DEFAULT_ENV_VAR_NAME}"
+            end
+
+            @logger = logger
+            @cw_agent_uri = URI.parse(conn_str)
+            if @cw_agent_uri.scheme != 'tcp' || !@cw_agent_uri.host || !@cw_agent_uri.port
+              raise Sinks::Error, "Expected connection string to be in format tcp://<host>:<port>, got '#{conn_str}'"
+            end
+
+            @max_queue_size = max_queue_size
+            @queue = Queue.new
+
+            @client_opts = TCPClient::Configuration.create(
+              buffered: false,
+              keep_alive: true,
+              connect_timeout: conn_timeout_secs,
+              write_timeout: write_timeout_secs
+            )
+
+            @lock = Mutex.new
+            @stop = false
+            start_sender(@queue)
+          end
+
+          def log_warn(msg)
+            @logger&.warn(msg)
+          end
+
+          def log_err(msg)
+            @logger&.error(msg)
+          end
+
+          def accept(message)
+            if @max_queue_size > -1 && @queue.length > @max_queue_size
+              log_warn("ECS Fargate Sink Queue is full (#{@max_queue_size} items)! Dropping metric message.")
+              return
+            end
+
+            @queue.push("#{JSON.dump(message)}\n")
+          end
+
+          #
+          # Shut down the sink. By default this blocks until all messages are sent to the agent, or
+          # the wait time elapses. No more messages will be accepted as soon as this is called.
+          #
+          # @param wait_time_seconds [Numeric] The seconds to wait for messages to be sent to the agent.
+          def shutdown(wait_time_seconds = 30)
+            # This is a blocking shutdown that will take no more messages
+            # but it will wait until all messages are eaten from the queue
+            @queue.close
+
+            start = Time.now.utc
+            until @queue.empty? || Time.now.utc > (start + wait_time_seconds)
+              # Yield this thread until the queue has processed
+              sleep(0)
+            end
+
+            @lock.synchronize do
+              @stop = true
+            end
+
+            return if @sender_thread.nil?
+
+            @sender_thread.join
+          end
+
+          def should_stop
+            @lock.synchronize do
+              @stop
+            end
+          end
+
+          def create_client(host, port, opts)
+            TCPClient.open("#{host}:#{port}", opts)
+          end
+
+          def start_sender(queue)
+            @sender_thread = Thread.new do
+              # Infinitely read from the queue and send messages to the agent
+              conn = nil
+              until should_stop
+                if queue.empty?
+                  # Thread yield; might be better to do a non-blocking `.pop`,
+                  # but then we have constant exception handling. Yuck.
+                  sleep(0)
+                  next
+                end
+
+                message = queue.pop
+                begin
+                  if conn.nil? || conn.closed?
+                    conn = create_client(@cw_agent_uri.host, @cw_agent_uri.port, @client_opts)
+                  end
+
+                  conn.write(message)
+                rescue Errno::ECONNREFUSED
+                  # Hopefully a transient issue, but the connection is gone. The sidecar may have died.
+                  conn.close unless conn.nil? || conn.closed?
+                  conn = nil
+                  # Throw in a small sleep so it doesn't hammer the connection trying to re-open
+                  sleep(0.1)
+                  # Unfortunately Ruby's thread-safe queue doesn't have a peek method.
+                  # The message has to go to the tail
+                  queue.push(message) unless queue.closed?
+                rescue StandardError => e
+                  queue.push(message) unless queue.closed?
+                  log_err("#{e.class}: #{e.message}: #{e.backtrace.join("\n")}")
+                end
+              end
+
+              conn&.close
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/aws-embedded-metrics-customink/sinks/sink_error.rb
+++ b/lib/aws-embedded-metrics-customink/sinks/sink_error.rb
@@ -1,0 +1,9 @@
+module Aws
+  module Embedded
+    module Metrics
+      module Sinks
+        class Error < StandardError; end
+      end
+    end
+  end
+end

--- a/lib/aws-embedded-metrics-customink/units.rb
+++ b/lib/aws-embedded-metrics-customink/units.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Aws
+  module Embedded
+    module Metrics
+      class Units
+        # Time
+        SECONDS = 'Seconds'
+        MICROSECONDS = 'Microseconds'
+        MILLISECONDS = 'Milliseconds'
+
+        # Size
+        BYTES = 'Bytes'
+        KILOBYTES = 'Kilobytes'
+        MEGABYTES = 'Megabytes'
+        GIGABYTES = 'Gigabytes'
+        TERABYTES = 'Terabytes'
+
+        BITS = 'Bits'
+        KILOBITS = 'Kilobits'
+        MEGABITS = 'Megabits'
+        GIGABITS = 'Gigabits'
+        TERABITS = 'Terabits'
+
+        # Simple units
+        PERCENT = 'Percent'
+        COUNT = 'Count'
+
+        # Size over time
+        BYTES_SECOND = "#{BYTES}/Second"
+        KILOBYTES_SECOND = "#{KILOBYTES}/Second"
+        MEGABYTES_SECOND = "#{MEGABYTES}/Second"
+        GIGABYTES_SECOND = "#{GIGABYTES}/Second"
+        TERABYTES_SECOND = "#{TERABYTES}/Second"
+
+        BITS_SECOND = "#{BITS}/Second"
+        KILOBITS_SECOND = "#{KILOBITS}/Second"
+        MEGABITS_SECOND = "#{MEGABITS}/Second"
+        GIGABITS_SECOND = "#{GIGABITS}/Second"
+        TERABITS_SECOND = "#{TERABITS}/Second"
+
+        COUNT_SECOND = "#{COUNT}/Second"
+
+        # Unit-less
+        NONE = 'None'
+      end
+    end
+  end
+end

--- a/lib/aws-embedded-metrics-customink/version.rb
+++ b/lib/aws-embedded-metrics-customink/version.rb
@@ -1,7 +1,7 @@
 module Aws
   module Embedded
     module Metrics
-      VERSION = '0.6.0'.freeze
+      VERSION = '0.7.0'.freeze
     end
   end
 end

--- a/test/cases/sinks/ecs_fargate_test.rb
+++ b/test/cases/sinks/ecs_fargate_test.rb
@@ -1,0 +1,195 @@
+require 'test_helper'
+require 'thread'
+
+module Sinks
+  class EcsFargateTest < TestCase
+    let(:port) { 23999 }
+    let(:server) { TcpSinkServer.new(port) }
+    let(:msg) { { hello: 'world' } }
+    let(:max_queue_size) { 3 }
+    let(:logger_content) { StringIO.new }
+    let(:logger) { Logger.new logger_content }
+    let(:sink) do
+      Aws::Embedded::Metrics::Sinks::EcsFargate.new(conn_str: "tcp://localhost:#{port}",
+                                                    max_queue_size: max_queue_size,
+                                                    conn_timeout_secs: 2,
+                                                    write_timeout_secs: 1,
+                                                    logger: logger)
+    end
+
+    it 'initializes with a connection string' do
+      expect(sink).must_be_instance_of Aws::Embedded::Metrics::Sinks::EcsFargate
+    end
+
+    it '#accept dumps its message to the server' do
+      server.start
+
+      sink.accept(msg)
+      sink.accept(msg)
+      sink.accept(msg)
+
+      sink.shutdown(1)
+      server.stop
+
+      assert_equal(server.data.length, 3)
+      (0..2).each { |i|
+        assert_equal(JSON.dump(msg), server.data[i].strip)
+      }
+    end
+
+    it '#accept throws if sending a message after it is shutdown' do
+      sink.shutdown(1)
+      assert_raises(ClosedQueueError) {
+        sink.accept(msg)
+      }
+    end
+
+    it 're-creates the connection if the connection is refused' do
+      # Create 2 fake clients that are returned on separate calls to create_client
+      # Send 2 messages, both of which will fail, forcing new clients.
+      fake_client1 = TCPClient.new
+      fake_client1.stubs(:write).raises(Errno::ECONNREFUSED, 'Expected').once
+
+      fake_client2 = TCPClient.new
+      fake_client2.stubs(:write).raises(Errno::ECONNREFUSED, 'Expected').once
+
+      sink.stubs(:create_client).returns(fake_client1, fake_client2)
+
+      sink.accept(msg)
+      sink.accept(msg)
+      sink.shutdown(1)
+    end
+
+    it 'reports unexpected errors over the logger' do
+      # Create 2 fake clients that are returned on separate calls to create_client
+      # Send 2 messages, both of which will fail, forcing new clients.
+      fake_client = TCPClient.new
+      fake_client.stubs(:write).raises(StandardError, 'Expected to fail')
+
+      sink.stubs(:create_client).returns(fake_client)
+
+      sink.accept(msg)
+      sink.shutdown(1)
+
+      assert_match(/StandardError/, logger_content.string, 'StandardError should have been logged')
+      assert_match(/Expected to fail/, logger_content.string, 'The error message should have been logged')
+    end
+
+    it 'reports queue sizes over the max over the logger' do
+      (0..max_queue_size + 2).each do |i|
+        sink.accept("Message #{i}")
+      end
+
+      sink.shutdown(1)
+      assert_equal(2, logger_content.string.split("\n").length, "There should be 2 messages dropped")
+      assert_match(/Queue is full/, logger_content.string, "The message should indicate the queue is full")
+    end
+
+    class TcpSinkServer
+      def initialize(port)
+        @port = port
+        @lock = Mutex.new
+        @data_queue = Queue.new
+        @data = ''
+        @stop = false
+        @server = nil
+      end
+
+      def data
+        until @data_queue.empty?
+          @data += @data_queue.pop
+        end
+        @data.split("\n")
+      end
+
+      def stop
+        @lock.synchronize do
+          @stop = true
+        end
+        close_server
+        @server_thread.join
+      end
+
+      def should_stop
+        @lock.synchronize do
+          @stop
+        end
+      end
+
+      def start
+        @server_thread = Thread.new {
+          begin
+            @server = TCPServer.open(@port)
+            client = accept_client
+
+            read_from_socket(client)
+
+            unless client.nil?
+              client.close
+            end
+
+            close_server
+          rescue StandardError => e
+            puts "Server Error! #{e}"
+            puts e.backtrace
+            close_server
+          end
+        }
+      end
+
+      def accept_client
+        begin
+          if should_stop
+            # If we should stop running, return now before accepting a client
+            close_server
+            return
+          end
+
+          client = @server.accept_nonblock
+          # If we don't set the client to UTF-8 it encodes the response as ASCII and the test fails
+          client.set_encoding('UTF-8')
+          return client
+        rescue IO::WaitReadable, Errno::EINTR
+          # The "correct" thing to do here is
+          # IO.select([@server]), which waits until a new connection is available on the socket.
+          # Good thing we aren't making a real server.
+          # Just spin-wait and exit if we get an exit signal.
+          sleep(0)
+          retry
+        end
+      end
+
+      def read_from_socket(sock)
+        if sock.nil?
+          return
+        end
+
+        until sock.closed?
+          begin
+            if should_stop
+              return
+            end
+            line = sock.read_nonblock(512)
+          rescue IO::WaitReadable
+            # The "correct" thing to do here is
+            # IO.select([sock]), which waits until data is available on the socket.
+            # Good thing we aren't making a real server.
+            # Just spin-wait and exit if we get an exit signal.
+            sleep(0)
+            retry
+          rescue EOFError
+            return
+          end
+
+          return if line.nil?
+          @data_queue << line
+        end
+      end
+
+      def close_server
+        @server&.close
+        @data_queue.close
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description

This is a neat little library, and I'd like to use it with ECS Fargate! Unfortunately for Fargate you can't just emit the EMF format into your logs. You have to pipe them over the network to a CloudWatch Log Agent.

This is the TCP implementation to do just that. I haven't yet tested this in my environment, but the messages look like they should work.

Given it's a bit of a "beefy" change, I wanted to get this PR out sooner than later.

### Changes

I've created a sink for ECS Fargate that immediately ingests all EMF requests and puts them into a queue. `Queue` is thread-safe by default in Ruby.

The sink starts a separate thread which reads from the queue and shovels messages over the wire. This way your main logic/program is never sitting around and blocking when e.g. a TCP connection goes down, the agent blocks, etc. 

##### Updated Dependencies
 - I added the [tcp-client](https://github.com/mblumtritt/tcp-client) gem, v0.11.2. I originally wrote my own client, but later thought better of that.
 - Concurrent-ruby automatically upgraded itself from 1.1.7 to 1.1.10.

### Ticket

<!-- Fill in the ticket information with the details of your feature -->
(Sorry, I can't add tickets to your Jira!)

[XX-1234](https://customink.atlassian.net/browse/XX-1234)


### Notes

_Recommended reading: [Code Review guide](https://github.com/customink/guides/blob/master/operations/code-review/README.md)_

<!--
Please include any notes that might be helpful for a reviewer to keep in mind while reading the changes.
-->

### Optional Tasks

<!--
Common, optional tasks are included here in case you forgot something important.
-->

I still need to update the readme! 🤦 

- [ ] Include 🎩 Instructions
- [ ] Update the readme (README.md)
- [ ] Update the API or architecture docs (e.g. docs/api.md)

##### Library-Specific

- [x] Increment the changelog (CHANGELOG.md)
- [x] Increment the version number (lib/version.rb)
- [ ] [Release & Tag][release] the version above in Github

[release]: https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository

##### Performance
- Are there any new queries in your change set that might require new indexes?
- Do any new queries require time-boxing to avoid table-scans when the data grows?

### What GIF Best Describes This Pull Request?


![Lets goooo](http://i.imgur.com/WHifiaH.gif)

