### PR TITLE
Add the TCP and Async sinks. Add support for log group name and log s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v0.7.0
+
+### Added
+
+- A new sink now exists, `EcsFargate`! Today the sink assumes you're using the `awsvpc` network configuration for your containers.
+- Included a new dependency, `tcp-client`. Originally a small hand-written TCP client was used but it proved unreliable and well outside the scope of this library.
+- Added the new `Units` class for easy reference to the accepted metric units.
+
 ## v0.6.0
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See this http://keepachangelog.com link for information on how we want this docu
 
 ### Added
 
-- A new sink now exists, `EcsFargate`! Today the sink assumes you're using the `awsvpc` network configuration for your containers.
+- Two new sinks now exists, `Tcp` and `Async`. The `Tcp` sink can EMF messages to any valid TCP endpoint, and `Async` can wrap any sink to ensure your program isn't impacted by writing to the network/disk/etc.
 - Included a new dependency, `tcp-client`. Originally a small hand-written TCP client was used but it proved unreliable and well outside the scope of this library.
 - Added the new `Units` class for easy reference to the accepted metric units.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,16 @@
 PATH
   remote: .
   specs:
-    aws-embedded-metrics-customink (0.6.0)
+    aws-embedded-metrics-customink (0.7.0)
       concurrent-ruby
+      tcp-client
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.1)
     coderay (1.1.3)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.10)
     method_source (1.0.0)
     minitest (5.14.1)
     mocha (1.11.2)
@@ -35,6 +36,7 @@ GEM
     rubocop-ast (0.2.0)
       parser (>= 2.7.0.1)
     ruby-progressbar (1.10.1)
+    tcp-client (0.11.2)
     unicode-display_width (1.7.0)
 
 PLATFORMS
@@ -49,4 +51,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.1.2
+   2.3.5

--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ Pulled from these two projects using the [Embedded Metric Format Specification](
 
 However, unlike these projects, we differ in the following ways. Again, contributions are very much welcome if you want to see more or change this.
 
-* Initial focus on Lambda. No other sinks.
-* As such, no default Dimensions or Configuraiton for:
-  - `LogGroupName`
-  - `LogStreamName`
+* Initial focus on Lambda. A TCP sink has been added, but no UDP sink exists.
+* An async sink wrapper exists that allows messages to be queued and sent on a separate thread.
+* No default Dimensions or Configuration for:
   - `ServiceName`
   - `ServiceType`
 
@@ -39,6 +38,9 @@ Simple configuration:
 ```ruby
 Aws::Embedded::Metrics.configure do |c|
   c.namespace = 'MyApplication'
+  # Optional
+  c.log_group_name = 'MyLogGroup'
+  c.log_stream_name = 'MyLogStream-UniqueID' 
 end
 ```
 
@@ -47,6 +49,24 @@ Using the `Logger` sink to write to a log file:
 ```ruby
 Aws::Embedded::Metrics.configure do |c|
   c.sink = Aws::Embedded::Metrics::Sinks::Logger.new(Rails.logger)
+end
+```
+
+Using the `Tcp` sink to write over a network:
+
+```ruby
+Aws::Embedded::Metrics.configure do |c|
+  c.sink = Aws::Embedded::Metrics::Sinks::Tcp.new(conn_str: "tcp://localhost:25888",
+                                                  logger: Rails.logger)
+end
+```
+
+Using the `Async` sink wrapper to incur no latency or errors on writes:
+```ruby
+Aws::Embedded::Metrics.configure do |c|
+  tcp_sink = Aws::Embedded::Metrics::Sinks::Tcp.new(conn_str: "tcp://localhost:25888",
+                                                    logger: Rails.logger)
+  c.sink = Aws::Embedded::Metrics::Sinks::Async.new(tcp_sink, logger: Rails.logger, max_queue_size: 1_000)
 end
 ```
 

--- a/aws-embedded-metrics-customink.gemspec
+++ b/aws-embedded-metrics-customink.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.add_dependency 'concurrent-ruby'
+  spec.add_dependency 'tcp-client'
 end

--- a/lib/aws-embedded-metrics-customink.rb
+++ b/lib/aws-embedded-metrics-customink.rb
@@ -6,6 +6,7 @@ require 'aws-embedded-metrics-customink/version'
 require 'aws-embedded-metrics-customink/sinks'
 require 'aws-embedded-metrics-customink/config'
 require 'aws-embedded-metrics-customink/logger'
+require 'aws-embedded-metrics-customink/units'
 require 'aws-embedded-metrics-customink/instance' if defined?(Rails)
 
 module Aws

--- a/lib/aws-embedded-metrics-customink/config.rb
+++ b/lib/aws-embedded-metrics-customink/config.rb
@@ -22,7 +22,10 @@ module Aws
 
         class Configuration
 
-          attr_writer :namespace, :sink
+          attr_writer :log_group_name,
+                      :log_stream_name,
+                      :namespace,
+                      :sink
 
           def reconfigure
             instance_variables.each { |var| instance_variable_set var, nil }
@@ -30,16 +33,27 @@ module Aws
             self
           end
 
+          def log_group_name
+            return @log_group_name if defined?(@log_group_name)
+
+            ENV.fetch('AWS_EMF_LOG_GROUP_NAME', nil)
+          end
+
+          def log_stream_name
+            return @log_stream_name if defined?(@log_stream_name)
+
+            ENV.fetch('AWS_EMF_LOG_STREAM_NAME', nil)
+          end
+
           def namespace
             return @namespace if defined?(@namespace)
 
-            ENV['AWS_EMF_NAMESPACE'] || 'aws-embedded-metrics'
+            ENV.fetch('AWS_EMF_NAMESPACE', 'aws-embedded-metrics')
           end
 
           def sink
             @sink ||= DEFAULT_SINK.new
           end
-
         end
       end
     end

--- a/lib/aws-embedded-metrics-customink/sinks.rb
+++ b/lib/aws-embedded-metrics-customink/sinks.rb
@@ -1,2 +1,6 @@
+require 'aws-embedded-metrics-customink/sinks/async'
 require 'aws-embedded-metrics-customink/sinks/logger'
 require 'aws-embedded-metrics-customink/sinks/stdout'
+require 'aws-embedded-metrics-customink/sinks/tcp'
+
+require 'aws-embedded-metrics-customink/sinks/sink_error'

--- a/lib/aws-embedded-metrics-customink/sinks/async.rb
+++ b/lib/aws-embedded-metrics-customink/sinks/async.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'tcp-client'
+
+module Aws
+  module Embedded
+    module Metrics
+      module Sinks
+        #
+        # Create a sink that will immediately take in messages, enqueue them, and forward them on to a sink.
+        class Async
+          attr_reader :queue, :sender
+
+          #
+          # Create a new Async sink which wraps an existing sink. This is most beneficial with the tcp sink.
+          #
+          # This was built as a performance-critical piece of code since metrics are often sent in high volumes.
+          # +#accept+, which is what takes in messages to send to the CW Metric Agent, puts messages into a thread-safe
+          # queue. A separate thread is then picking up from that queue and sending the messages to the chosen sink.
+          #
+          # <b>Creating a new Async sink will create a new thread.</b> This sink is intended to be used sparingly.
+          #
+          # Messages that sent to the sink; no more information is known about the message after that.
+          # If the sink cannot process the message, it is lost.
+          #
+          # If a message is enqueued and the queue is full, the message is dropped and a warning is logged.
+          # @param sink [Sink] A sink to wrap. +#accept+ will be the only method called on the sink.
+          # @param logger [Logger] A standard Ruby logger to propagate warnings and errors.
+          #   Suggested to use Rails.logger.
+          # @param max_queue_size [Numeric] The number of messages to buffer in-memory.
+          #   A negative value will buffer everything.
+          def initialize(sink,
+                         logger: nil,
+                         max_queue_size: 1_000)
+            raise Sinks::Error, 'Must specify a sink to wrap' if sink.nil?
+
+            @sink = sink
+
+            @max_queue_size = max_queue_size
+            @queue = Queue.new
+            @lock = Mutex.new
+            @stop = false
+            @logger = logger
+            start_sender(@queue)
+          end
+
+          def accept(message)
+            if @max_queue_size > -1 && @queue.length > @max_queue_size
+              @logger&.warn("Async metrics queue is full (#{@max_queue_size} items)! Dropping metric message.")
+              return
+            end
+
+            @queue.push(message)
+          end
+
+          #
+          # Shut down the sink. By default this blocks until all messages are sent to the agent, or
+          # the wait time elapses. No more messages will be accepted as soon as this is called.
+          #
+          # @param wait_time_seconds [Numeric] The seconds to wait for messages to be sent to the agent.
+          def shutdown(wait_time_seconds = 30)
+            # We push a "stop" message to ensure there's something in the queue,
+            # otherwise it will indefinitely block.
+            # When a "stop message" comes through it will break the loop.
+            @queue.push(StopMessage.new)
+            @queue.close
+
+            start = Time.now.utc
+            until @queue.empty? || Time.now.utc > (start + wait_time_seconds)
+              # Yield this thread until the queue has processed
+              sleep(0)
+            end
+
+            # If we haven't been able to eat through the queue, this should terminate the loop
+            # and allow the thread to rejoin.
+            @lock.synchronize do
+              @stop = true
+            end
+
+            @sender_thread&.join
+          end
+
+          def should_stop
+            @lock.synchronize do
+              @stop
+            end
+          end
+
+          def start_sender(queue)
+            @sender_thread = Thread.new do
+              stop_message_class = StopMessage.new.class
+              # Infinitely read from the queue and send messages to the agent
+              until should_stop
+                # We use a special message class to ensure
+                message = queue.pop
+                break if stop_message_class == message.class
+
+                @sink.accept(message)
+              end
+            end
+          end
+
+          # Special class to signal that the thread should exit and finish.
+          class StopMessage; end
+          private_constant :StopMessage
+        end
+      end
+    end
+  end
+end

--- a/lib/aws-embedded-metrics-customink/sinks/sink_error.rb
+++ b/lib/aws-embedded-metrics-customink/sinks/sink_error.rb
@@ -1,0 +1,9 @@
+module Aws
+  module Embedded
+    module Metrics
+      module Sinks
+        class Error < StandardError; end
+      end
+    end
+  end
+end

--- a/lib/aws-embedded-metrics-customink/sinks/tcp.rb
+++ b/lib/aws-embedded-metrics-customink/sinks/tcp.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'tcp-client'
+
+module Aws
+  module Embedded
+    module Metrics
+      module Sinks
+        #
+        # Create a sink that will communicate to a CloudWatch Log Agent over a TCP connection.
+        #
+        # See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Generation_CloudWatch_Agent.html
+        # for configuration information
+        class Tcp
+          AWS_EMF_AGENT_ENDPOINT_ENV_VAR = 'AWS_EMF_AGENT_ENDPOINT'
+          attr_reader :queue
+          attr :client_opts
+
+          #
+          # Create a new TCP sink. It will use the +AWS_EMF_AGENT_ENDPOINT+ environment variable by default to
+          # connect to a CloudWatch Metric Agent.
+          #
+          # @param conn_str [String] A connection string, formatted like 'tcp://127.0.0.1:25888'.
+          # @param conn_timeout_secs [Numeric] The number of seconds before timing out the connection to the agent.
+          # @param write_timeout_secs [Numeric] The number of seconds to wait before timing out a write.
+          # @param logger [Logger] A standard Ruby logger to propagate warnings and errors.
+          #   Suggested to use Rails.logger.
+          def initialize(conn_str: ENV.fetch(AWS_EMF_AGENT_ENDPOINT_ENV_VAR, nil),
+                         conn_timeout_secs: 10,
+                         write_timeout_secs: 10,
+                         logger: nil)
+            if conn_str.nil?
+              raise Sinks::Error, "Must specify a connection string or set environment variable #{AWS_EMF_AGENT_ENDPOINT_ENV_VAR}"
+            end
+
+            @logger = logger
+            @cw_agent_uri = URI.parse(conn_str)
+            if @cw_agent_uri.scheme != 'tcp' || !@cw_agent_uri.host || !@cw_agent_uri.port
+              raise Sinks::Error, "Expected connection string to be in format tcp://<host>:<port>, got '#{conn_str}'"
+            end
+
+            @client_opts = TCPClient::Configuration.create(
+              buffered: true,
+              keep_alive: true,
+              reverse_lookup: true,
+              connect_timeout: conn_timeout_secs,
+              write_timeout: write_timeout_secs
+            )
+            @conn = nil
+          end
+
+          def log_warn(msg)
+            @logger&.warn(msg)
+          end
+
+          def log_err(msg)
+            @logger&.error(msg)
+          end
+
+          def create_conn(host, port, opts)
+            TCPClient.open("#{host}:#{port}", opts)
+          end
+
+          def connection
+            @conn = create_conn(@cw_agent_uri.host, @cw_agent_uri.port, @client_opts) if @conn.nil? || @conn.closed?
+            @conn
+          end
+
+          def send_message(message)
+            retries = 2
+            conn = nil
+            begin
+              conn = connection
+              conn.write(message)
+            rescue Errno::ECONNREFUSED
+              conn.close unless conn.nil? || conn.closed?
+              log_warn("Could not connect to CloudWatch Agent at #{@cw_agent_uri.scheme}://#{@cw_agent_uri.host}:#{@cw_agent_uri.port}")
+              retries -= 1
+              retry if retries >= 0
+            rescue StandardError => e
+              log_err("#{e.class}: #{e.message}: #{e.backtrace.join("\n")}")
+            end
+          end
+
+          def accept(message)
+            send_message("#{JSON.dump(message)}\n")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/aws-embedded-metrics-customink/units.rb
+++ b/lib/aws-embedded-metrics-customink/units.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Aws
+  module Embedded
+    module Metrics
+      class Units
+        # Time
+        SECONDS = 'Seconds'
+        MICROSECONDS = 'Microseconds'
+        MILLISECONDS = 'Milliseconds'
+
+        # Size
+        BYTES = 'Bytes'
+        KILOBYTES = 'Kilobytes'
+        MEGABYTES = 'Megabytes'
+        GIGABYTES = 'Gigabytes'
+        TERABYTES = 'Terabytes'
+
+        BITS = 'Bits'
+        KILOBITS = 'Kilobits'
+        MEGABITS = 'Megabits'
+        GIGABITS = 'Gigabits'
+        TERABITS = 'Terabits'
+
+        # Simple units
+        PERCENT = 'Percent'
+        COUNT = 'Count'
+
+        # Size over time
+        BYTES_SECOND = "#{BYTES}/Second"
+        KILOBYTES_SECOND = "#{KILOBYTES}/Second"
+        MEGABYTES_SECOND = "#{MEGABYTES}/Second"
+        GIGABYTES_SECOND = "#{GIGABYTES}/Second"
+        TERABYTES_SECOND = "#{TERABYTES}/Second"
+
+        BITS_SECOND = "#{BITS}/Second"
+        KILOBITS_SECOND = "#{KILOBITS}/Second"
+        MEGABITS_SECOND = "#{MEGABITS}/Second"
+        GIGABITS_SECOND = "#{GIGABITS}/Second"
+        TERABITS_SECOND = "#{TERABITS}/Second"
+
+        COUNT_SECOND = "#{COUNT}/Second"
+
+        # Unit-less
+        NONE = 'None'
+      end
+    end
+  end
+end

--- a/lib/aws-embedded-metrics-customink/version.rb
+++ b/lib/aws-embedded-metrics-customink/version.rb
@@ -1,7 +1,7 @@
 module Aws
   module Embedded
     module Metrics
-      VERSION = '0.6.0'.freeze
+      VERSION = '0.7.0'.freeze
     end
   end
 end

--- a/test/cases/sinks/async_test.rb
+++ b/test/cases/sinks/async_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+require 'thread'
+
+module Sinks
+  class AsyncTest < TestCase
+    let(:port) { 23999 }
+    let(:server) { TestTcpSinkServer.new(port) }
+    let(:msg) { { hello: 'world' } }
+    let(:max_queue_size) { 3 }
+    let(:logger_content) { StringIO.new }
+    let(:logger) { Logger.new logger_content }
+    let(:wrapped_sink) do
+      Aws::Embedded::Metrics::Sinks::Tcp.new(conn_str: "tcp://localhost:#{port}",
+                                             conn_timeout_secs: 2,
+                                             write_timeout_secs: 1,
+                                             logger: logger)
+    end
+    let(:sink) do
+      Aws::Embedded::Metrics::Sinks::Async.new(wrapped_sink,
+                                               logger: logger,
+                                               max_queue_size: max_queue_size)
+    end
+
+    it 'initializes with a connection string' do
+      expect(sink).must_be_instance_of Aws::Embedded::Metrics::Sinks::Async
+    end
+
+    it '#accept dumps its message to the server' do
+      server.start
+
+      sink.accept(msg)
+      sink.accept(msg)
+      sink.accept(msg)
+
+      sink.shutdown(1)
+      Timeout::timeout(1) {
+        until server.data.length >= 3;
+        end
+      }
+
+      assert_equal(3, server.data.length)
+      (0..2).each { |i|
+        assert_equal(JSON.dump(msg), server.data[i].strip)
+      }
+      server.stop
+    end
+
+    it '#accept throws if sending a message after it is shutdown' do
+      sink.shutdown(1)
+      assert_raises(ClosedQueueError) {
+        sink.accept(msg)
+      }
+    end
+
+    it 'reports queue sizes over the max over the logger' do
+      (0..max_queue_size + 2).each do |i|
+        sink.accept("Message #{i}")
+      end
+
+      sink.shutdown(1)
+      assert_equal(2,
+                   logger_content.string.scan("Async metrics queue is full").length,
+                   "There should be 2 messages dropped")
+    end
+  end
+end

--- a/test/cases/sinks/tcp_test.rb
+++ b/test/cases/sinks/tcp_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+require 'thread'
+
+module Sinks
+  class TcpTest < TestCase
+    let(:port) { 23999 }
+    let(:server) { TestTcpSinkServer.new(port) }
+    let(:msg) { { hello: 'world' } }
+    let(:logger_content) { StringIO.new }
+    let(:logger) { Logger.new logger_content }
+    let(:sink) do
+      Aws::Embedded::Metrics::Sinks::Tcp.new(conn_str: "tcp://localhost:#{port}",
+                                             conn_timeout_secs: 2,
+                                             write_timeout_secs: 1,
+                                             logger: logger)
+    end
+
+    it 'initializes with a connection string' do
+      expect(sink).must_be_instance_of Aws::Embedded::Metrics::Sinks::Tcp
+    end
+
+    it '#accept dumps its message to the server' do
+      server.start
+
+      sink.accept(msg)
+      sink.accept(msg)
+      sink.accept(msg)
+      sink.connection.close
+
+      Timeout::timeout(1) {
+        until server.data.length == 3; end
+      }
+
+      assert_equal(3, server.data.length)
+      (0..2).each { |i|
+        assert_equal(JSON.dump(msg), server.data[i].strip)
+      }
+      server.stop
+    end
+
+    it 're-creates the connection if the connection is refused with retries' do
+      # Create 2 fake clients that are returned on separate calls to create_client
+      # Send 2 messages, both of which will fail, forcing new clients.
+      fake_client1 = TCPClient.new
+      fake_client1.stubs(:write).raises(Errno::ECONNREFUSED, 'Expected').once
+
+      fake_client2 = TCPClient.new
+      fake_client2.stubs(:write).raises(Errno::ECONNREFUSED, 'Expected').times(2)
+
+      sink.stubs(:connection).returns(fake_client1, fake_client2)
+
+      sink.accept(msg)
+    end
+
+    it 'reports unexpected errors over the logger' do
+      # Create 2 fake clients that are returned on separate calls to create_client
+      # Send 2 messages, both of which will fail, forcing new clients.
+      fake_client = TCPClient.new
+      fake_client.stubs(:write).raises(StandardError, 'Expected to fail')
+
+      sink.stubs(:connection).returns(fake_client)
+
+      sink.accept(msg)
+
+      assert_match(/StandardError/, logger_content.string, 'StandardError should have been logged')
+      assert_match(/Expected to fail/, logger_content.string, 'The error message should have been logged')
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require 'bundler' ; Bundler.require :default, :development, :test
 require 'aws-embedded-metrics-customink'
 require_relative 'test_helper/test_sink.rb'
+require_relative 'test_helper/test_tcp_sink_server.rb'
 require 'minitest/spec'
 require 'minitest/autorun'
 

--- a/test/test_helper/test_tcp_sink_server.rb
+++ b/test/test_helper/test_tcp_sink_server.rb
@@ -1,0 +1,108 @@
+module Sinks
+  class TestTcpSinkServer
+    def initialize(port)
+      @port = port
+      @lock = Mutex.new
+      @data_queue = Queue.new
+      @data = ''
+      @stop = false
+      @server = nil
+    end
+
+    def data
+      until @data_queue.empty?
+        @data += @data_queue.pop
+      end
+      @data.split("\n")
+    end
+
+    def stop
+      @lock.synchronize do
+        @stop = true
+      end
+      close_server
+      @server_thread.join
+    end
+
+    def should_stop
+      @lock.synchronize do
+        @stop
+      end
+    end
+
+    def start
+      @server_thread = Thread.new {
+        begin
+          @server = TCPServer.open(@port)
+          client = accept_client
+
+          read_from_socket(client)
+
+          unless client.nil?
+            client.close
+          end
+
+          close_server
+        rescue StandardError => e
+          puts "Server Error! #{e}"
+          puts e.backtrace
+          close_server
+        end
+      }
+    end
+
+    def accept_client
+      begin
+        if should_stop
+          # If we should stop running, return now before accepting a client
+          close_server
+          return
+        end
+
+        client = @server.accept_nonblock
+        # If we don't set the client to UTF-8 it encodes the response as ASCII and the test fails
+        client.set_encoding('UTF-8')
+        return client
+      rescue IO::WaitReadable, Errno::EINTR
+        # The "correct" thing to do here is
+        # IO.select([@server]), which waits until a new connection is available on the socket.
+        # Good thing we aren't making a real server.
+        # Just spin-wait and exit if we get an exit signal.
+        sleep(0)
+        retry
+      end
+    end
+
+    def read_from_socket(sock)
+      if sock.nil?
+        return
+      end
+
+      until sock.closed?
+        begin
+          if should_stop
+            return
+          end
+          line = sock.read_nonblock(512)
+        rescue IO::WaitReadable
+          # The "correct" thing to do here is
+          # IO.select([sock]), which waits until data is available on the socket.
+          # Good thing we aren't making a real server.
+          # Just spin-wait and exit if we get an exit signal.
+          sleep(0)
+          retry
+        rescue EOFError
+          return
+        end
+
+        return if line.nil?
+        @data_queue << line
+      end
+    end
+
+    def close_server
+      @server&.close
+      @data_queue.close
+    end
+  end
+end


### PR DESCRIPTION
…tream name. Add the Units reference.

### Description

This adds a TCP and Async sink. These allow non-Lambda deployments (e.g. ECS Fargate) to communicate to a CloudWatch Log Agent running as a side-car.

The Async sink can wrap any sink to allow processing to happen in the background. This ensures that production code isn't affected by network communicate to the agent.

There's also a new Units file that references all of the known units for CloudWatch.

### Changes

The TCP sink will attempt to connect to the TCP endpoint up to 3 times before giving up. Errors will be sent back over a logger if it was supplied.

The Async sink will start a new thread when it's created, wrapping an existing sink. `#accept` pushes messages to a queue, which is `#pop`'d by the thread and sent to the sink's `#accept`.

Messages that exceed the maximum queue size are dropped.

##### Updated Dependencies
 - I added the [tcp-client](https://github.com/mblumtritt/tcp-client) gem, v0.11.2. I originally wrote my own client, but later thought better of that.
- Concurrent-ruby automatically upgraded itself from 1.1.7 to 1.1.10.

### Ticket

N/A

### Screenshots

N/A

### Notes

_Recommended reading: [Code Review guide](https://github.com/customink/guides/blob/master/operations/code-review/README.md)_

<!--
Please include any notes that might be helpful for a reviewer to keep in mind while reading the changes.
-->

### Optional Tasks

<!--
Common, optional tasks are included here in case you forgot something important.
-->

- [X] Include 🎩 Instructions
- [X] Update the readme (README.md)
- [X] Update the API or architecture docs (e.g. docs/api.md)

##### Library-Specific

- [X] Increment the changelog (CHANGELOG.md)
- [X] Increment the version number (lib/version.rb)
- [ ] [Release & Tag][release] the version above in Github

[release]: https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository

##### Performance

It's working in a beta environment serving real traffic and performance seems stable :)